### PR TITLE
Make materialization of primary keys configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ cd target-clickhouse
 poetry install --all-extras
 ```
 
+### Testing
+
+The test suite includes tests for core functionality and validation. Before running tests, start the ClickHouse container:
+
+```bash
+# Start ClickHouse container
+./docker_run_clickhouse.sh
+
+# Run all tests
+poetry run pytest
+```
+
 ## Configuration
 
 ### Connection Settings
@@ -194,15 +206,6 @@ plugins:
 - `ReplicatedAggregatingMergeTree`
 
 For more information about ClickHouse table engines, refer to the [official documentation](https://clickhouse.com/docs/en/engines/table-engines).
-
-### Testing
-
-The test suite includes tests for core functionality and validation. The test environment is automatically set up and torn down as needed.
-
-```bash
-# Run all tests
-poetry run pytest
-```
 
 ### Code Quality
 

--- a/README.md
+++ b/README.md
@@ -68,16 +68,17 @@ poetry install --all-extras
 
 ### Table Settings
 
-| Setting               | Required | Default | Description                                                 |
-| :-------------------- | :------- | :------ | :---------------------------------------------------------- |
-| engine_type           | False    | None    | Table engine type (e.g., MergeTree, ReplacingMergeTree)     |
-| table_name            | False    | None    | Target table name (defaults to stream name)                 |
-| table_path            | False    | None    | Table path for replicated tables (required for replication) |
-| replica_name          | False    | None    | Replica name for replicated tables                          |
-| cluster_name          | False    | None    | Cluster name for distributed tables                         |
-| default_target_schema | False    | None    | Default target schema/database for all streams              |
-| optimize_after        | False    | false   | Run OPTIMIZE TABLE after insert (useful for deduplication)  |
-| order_by_keys         | False    | None    | Columns to order by (required for MergeTree engines)        |
+| Setting                  | Required | Default | Description                                                 |
+| :----------------------- | :------- | :------ | :---------------------------------------------------------- |
+| engine_type              | False    | None    | Table engine type (e.g., MergeTree, ReplacingMergeTree)     |
+| table_name               | False    | None    | Target table name (defaults to stream name)                 |
+| table_path               | False    | None    | Table path for replicated tables (required for replication) |
+| replica_name             | False    | None    | Replica name for replicated tables                          |
+| cluster_name             | False    | None    | Cluster name for distributed tables                         |
+| default_target_schema    | False    | None    | Default target schema/database for all streams              |
+| optimize_after           | False    | false   | Run OPTIMIZE TABLE after insert (useful for deduplication)  |
+| order_by_keys            | False    | None    | Columns to order by (required for MergeTree engines)        |
+| materialize_primary_keys | False    | true    | Whether to materialize primary keys in the database         |
 
 ### Data Loading Settings
 

--- a/docker_run_clickhouse.sh
+++ b/docker_run_clickhouse.sh
@@ -1,1 +1,1 @@
-docker run -p 18123:8123 -p 19000:9000 --rm --name clickhouse-server --ulimit nofile=262144:262144 clickhouse/clickhouse-server:23.4-alpine $args
+docker run -p 18123:8123 -p 19000:9000 --rm --name clickhouse-server --ulimit nofile=262144:262144 clickhouse/clickhouse-server:24.10-alpine $args

--- a/meltano.yml
+++ b/meltano.yml
@@ -104,3 +104,9 @@ plugins:
           documentation: >
             https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/
             mergetree#mergetree-query-clauses
+        - name: materialize_primary_keys
+          kind: boolean
+          value: true
+          description: >
+            Whether to materialize primary keys in the database. If false, primary keys
+            will only be used for ordering when no order_by_keys are specified.

--- a/target_clickhouse/target.py
+++ b/target_clickhouse/target.py
@@ -144,6 +144,17 @@ class TargetClickhouse(SQLTarget):
             description="List of columns to order by. Used for engines that require "
             "ordering.",
         ),
+        th.Property(
+            "materialize_primary_keys",
+            th.BooleanType,
+            required=False,
+            default=True,
+            description=(
+                "Whether to materialize primary keys in the database. If false, "
+                "primary keys will only be used for ordering when no order_by_keys "
+                "are specified."
+            ),
+        ),
     ).to_dict()
 
     default_sink_class = ClickhouseSink

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,60 +2,10 @@
 
 from pathlib import Path
 
-import docker
 import pytest
 from singer_sdk.testing.templates import TargetFileTestTemplate
 
 pytest_plugins = ()
-
-
-@pytest.fixture(scope="session")
-def clickhouse_container():
-    """
-    Create a ClickHouse container for testing.
-
-    In CI, this fixture is a no-op since ClickHouse is provided via GitHub Actions
-    services.
-    """
-    import os
-    import time
-
-    import requests
-
-    # Skip container creation if we're in GitHub Actions
-    if os.getenv("GITHUB_ACTIONS"):
-        # Just wait for the service to be ready
-        while (
-            requests.get("http://localhost:18123/ping", timeout=1).text.strip() != "Ok."
-        ):
-            time.sleep(1)
-        yield None
-        return
-
-    # Local development setup
-    client = docker.from_env()
-    client.images.pull("clickhouse/clickhouse-server", tag="24.10-alpine")
-
-    container = client.containers.run(
-        "clickhouse/clickhouse-server:24.10-alpine",
-        name="clickhouse-server",
-        ports={"8123/tcp": 18123, "9000/tcp": 19000},
-        ulimits=[docker.types.Ulimit(name="nofile", soft=262144, hard=262144)],
-        environment={
-            "CLICKHOUSE_DB": "default",
-            "CLICKHOUSE_USER": "default",
-            "CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT": "1",
-        },
-        detach=True,
-        remove=True,
-    )
-
-    # Wait for ClickHouse to be ready
-    while requests.get("http://localhost:18123/ping", timeout=1).text.strip() != "Ok.":
-        time.sleep(1)
-
-    yield container
-    container.stop()
 
 
 class TargetClickhouseFileTestTemplate(TargetFileTestTemplate):
@@ -64,11 +14,6 @@ class TargetClickhouseFileTestTemplate(TargetFileTestTemplate):
 
     Use this when sourcing Target test input from a .singer file.
     """
-
-    @pytest.fixture(autouse=True)
-    def _setup_clickhouse(self, clickhouse_container):
-        """Set up ClickHouse container for tests."""
-        self.clickhouse_container = clickhouse_container
 
     @property
     def singer_filepath(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 
-import pytest
 from singer_sdk.testing.templates import TargetFileTestTemplate
 
 pytest_plugins = ()

--- a/tests/target_test_cases.py
+++ b/tests/target_test_cases.py
@@ -1,12 +1,50 @@
 import datetime
 import logging
+from typing import Any
 
 from singer_sdk.testing.suites import TestSuite
 from sqlalchemy import text
 
+from target_clickhouse.connectors import ClickhouseConnector
 from tests.conftest import TargetClickhouseFileTestTemplate
 
 logger = logging.getLogger(__name__)
+
+
+class TestConnector(ClickhouseConnector):
+    """Test connector with additional methods for testing."""
+
+    def get_table_ddl(self, table_name: str) -> str:  # noqa: S608
+        """
+        Get the DDL for a table.
+
+        Args:
+            table_name: The name of the table.
+
+        Returns:
+            The DDL for the table.
+
+        """
+        with self._connect() as conn:
+            result = conn.execute(
+                text(f"SHOW CREATE TABLE {table_name}"),
+            ).fetchall()
+            return result[0][0]
+
+    def get_table_records(self, table_name: str) -> list[Any]:
+        """
+        Get all records from a table.
+
+        Args:
+            table_name: The name of the table.
+
+        Returns:
+            List of records.
+
+        """
+        with self._connect() as conn:
+            # ruff: noqa: S608
+            return conn.execute(text(f"SELECT * FROM {table_name}")).fetchall()
 
 
 class TestDateTypeTargetClickhouse(TargetClickhouseFileTestTemplate):
@@ -16,7 +54,7 @@ class TestDateTypeTargetClickhouse(TargetClickhouseFileTestTemplate):
 
     def validate(self) -> None:
         """Validate the data in the target."""
-        connector = self.target.default_sink_class.connector_class(self.target.config)
+        connector = TestConnector(self.target.config)
         records = {
             1: datetime.date(2024, 3, 15),
             2: datetime.date(2024, 3, 16),
@@ -24,9 +62,7 @@ class TestDateTypeTargetClickhouse(TargetClickhouseFileTestTemplate):
             4: None,
         }
 
-        result = connector.connection.execute(
-            statement=text("SELECT * FROM date_type"),
-        ).fetchall()
+        result = connector.get_table_records("date_type")
 
         for record_id, expected_date in records.items():
             record = next((rec for rec in result if rec[0] == record_id), None)
@@ -36,9 +72,55 @@ class TestDateTypeTargetClickhouse(TargetClickhouseFileTestTemplate):
             ), f"For record {record_id}, expected {expected_date}, got {record[1]}"
 
 
+class TestPrimaryKeyMaterialized(TargetClickhouseFileTestTemplate):
+    """
+    Test that primary keys are correctly materialized.
+
+    This test verifies behavior when materialize_primary_keys=True.
+    """
+
+    name = "primary_key_materialized"
+
+    def validate(self) -> None:
+        """Validate the table structure in ClickHouse."""
+        connector = TestConnector(self.target.config)
+
+        # Check if primary key is materialized
+        create_table_ddl = connector.get_table_ddl("primary_key_materialized")
+        assert (
+            "PRIMARY KEY id" in create_table_ddl
+        ), "Expected PRIMARY KEY id in table DDL"
+
+
+class TestPrimaryKeyNotMaterialized(TargetClickhouseFileTestTemplate):
+    """
+    Test that primary keys are not materialized.
+
+    This test verifies behavior when materialize_primary_keys=False.
+    """
+
+    name = "primary_key_not_materialized"
+
+    def validate(self) -> None:
+        """Validate the table structure in ClickHouse."""
+        connector = TestConnector(self.target.config)
+
+        # Check if primary key is not materialized
+        create_table_ddl = connector.get_table_ddl("primary_key_not_materialized")
+        assert (
+            "PRIMARY KEY" not in create_table_ddl
+        ), "Expected no PRIMARY KEY in table DDL"
+        assert "ORDER BY id" in create_table_ddl, "Expected ORDER BY id in table DDL"
+
+
+# Combined test suite with all test cases
 custom_target_test_suite = TestSuite(
     kind="target",
-    tests=[
-        TestDateTypeTargetClickhouse,
-    ],
+    tests=[TestDateTypeTargetClickhouse, TestPrimaryKeyMaterialized],
+)
+
+# Combined test suite with non-materialized primary keys config.
+custom_target_test_suite_non_materialized_primary_keys = TestSuite(
+    kind="target",
+    tests=[TestPrimaryKeyNotMaterialized],
 )

--- a/tests/target_test_streams/primary_key_materialized.singer
+++ b/tests/target_test_streams/primary_key_materialized.singer
@@ -1,0 +1,3 @@
+{"type": "SCHEMA", "stream": "primary_key_materialized", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "string"}}}}
+{"type": "RECORD", "stream": "primary_key_materialized", "record": {"id": 1, "value": "first"}}
+{"type": "RECORD", "stream": "primary_key_materialized", "record": {"id": 2, "value": "second"}}

--- a/tests/target_test_streams/primary_key_not_materialized.singer
+++ b/tests/target_test_streams/primary_key_not_materialized.singer
@@ -1,0 +1,3 @@
+{"type": "SCHEMA", "stream": "primary_key_not_materialized", "key_properties": ["id"], "schema": {"required": ["id"], "type": "object", "properties": {"id": {"type": "integer"}, "value": {"type": "string"}}}}
+{"type": "RECORD", "stream": "primary_key_not_materialized", "record": {"id": 1, "value": "first"}}
+{"type": "RECORD", "stream": "primary_key_not_materialized", "record": {"id": 2, "value": "second"}}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,10 @@ import typing as t
 from singer_sdk.testing import get_target_test_class
 
 from target_clickhouse.target import TargetClickhouse
-from tests.target_test_cases import custom_target_test_suite
+from tests.target_test_cases import (
+    custom_target_test_suite,
+    custom_target_test_suite_non_materialized_primary_keys,
+)
 
 TEST_CONFIG: dict[str, t.Any] = {
     "sqlalchemy_url": "clickhouse+http://default:@localhost:18123",
@@ -36,6 +39,18 @@ TEST_CONFIG_NATIVE: dict[str, t.Any] = {
     "verify": False,
 }
 
+TEST_CONFIG_NON_MATERIALIZED_PRIMARY_KEYS: dict[str, t.Any] = {
+    "driver": "http",
+    "host": "localhost",
+    "port": 18123,
+    "username": "default",
+    "password": "",
+    "database": "default",
+    "secure": False,
+    "verify": False,
+    "materialize_primary_keys": False,
+}
+
 # Run standard built-in target tests from the SDK:
 StandardTargetTests = get_target_test_class(
     target_class=TargetClickhouse,
@@ -45,7 +60,7 @@ StandardTargetTests = get_target_test_class(
 
 
 class TestStandardTargetClickhouse(
-    StandardTargetTests,  # type: ignore[misc, valid-type]
+    StandardTargetTests,  # type: ignore[valid-type]
 ):
     """Standard Target Tests."""
 
@@ -57,5 +72,18 @@ SpreadTargetTests = get_target_test_class(
 )
 
 
-class TestSpreadTargetClickhouse(SpreadTargetTests):  # type: ignore[misc, valid-type]
+class TestSpreadTargetClickhouse(SpreadTargetTests):  # type: ignore[valid-type]
+    """Standard Target Tests."""
+
+
+NonMaterializedPrimaryKeysTargetTests = get_target_test_class(
+    target_class=TargetClickhouse,
+    config=TEST_CONFIG_NON_MATERIALIZED_PRIMARY_KEYS,
+    custom_suites=[custom_target_test_suite_non_materialized_primary_keys],
+)
+
+
+class TestNonMaterializedPrimaryKeysTargetClickhouse(
+    NonMaterializedPrimaryKeysTargetTests  # type: ignore[valid-type]
+):
     """Standard Target Tests."""


### PR DESCRIPTION
## Description

Add a configuration `materialize_primary_keys` which, when set to False, primary key is not materialized in the target table, only `order by` keys. This is especially helpful as order by keys can be edited after the fact with an `alter table` whereas primary keys cannot.

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)

## Testing

- Added two nest test cases to verify the new configuration works.