### PR TITLE
Fix update version CI pipeline

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -28,6 +28,8 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          git checkout -b temp-version-update
           git add pyproject.toml
           git commit -m "chore: update version to $VERSION [skip ci]"
-          git push
+          git push origin HEAD:main
+          git branch -D temp-version-update


### PR DESCRIPTION
## Description

The purpose of this PR is to fix the `update-version` github actions workflow, ensuring that we first create a branch, commit to it with the new version, push to main and delete the branch, instead of trying to commit to a detached `HEAD`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)