### PR TITLE
Use synchronous model when running optimize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,9 @@ dmypy.json
 
 # JetBrains IDE config
 .idea/
+
+# VSCode IDE config
+.vscode/
+
+# MacOS
+.DS_Store

--- a/target_clickhouse/connectors.py
+++ b/target_clickhouse/connectors.py
@@ -49,7 +49,9 @@ class ClickhouseConnector(SQLConnector):
 
         if config["driver"] == "http":
             if config["secure"]:
-                secure_options = f"protocol=https&verify={config['verify']}"
+                secure_options = (
+                    f"protocol=https&verify={config['verify']}&alter_sync=2"
+                )
 
                 if not config["verify"]:
                     # disable urllib3 warning
@@ -57,9 +59,11 @@ class ClickhouseConnector(SQLConnector):
 
                     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
             else:
-                secure_options = "protocol=http"
+                secure_options = "protocol=http&alter_sync=2"
         else:
-            secure_options = f"secure={config['secure']}&verify={config['verify']}"
+            secure_options = (
+                f"secure={config['secure']}&verify={config['verify']}&alter_sync=2"
+            )
         return (
             f"clickhouse+{config['driver']}://{config['username']}:{config['password']}@"
             f"{config['host']}:{config['port']}/"


### PR DESCRIPTION
## Description

The purpose of this PR is to run optimize commands in synchronous mode (`alter_sync` setting set to `2` - wait for everyone), avoiding issues like `clickhouse_sqlalchemy.exceptions.DatabaseException: Orig exception: Code: 388. DB::Exception: Cannot run optimize, background pool is already full, try to execute in synchronous mode (alter_sync >= 1). (CANNOT_ASSIGN_OPTIMIZE)` when running optimization.

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)
