### PR TITLE
feat: Improve changelog and PR template

### DIFF
--- a/.github/changelog-config.json
+++ b/.github/changelog-config.json
@@ -2,22 +2,118 @@
   "categories": [
     {
       "title": "## 🚀 Features",
-      "labels": ["feature"]
+      "labels": ["feature", "enhancement"]
     },
     {
       "title": "## 🐛 Bug Fixes",
-      "labels": ["fix"]
+      "labels": ["fix", "bug"]
     },
     {
       "title": "## 📝 Documentation",
-      "labels": ["documentation"]
+      "labels": ["documentation", "docs"]
     },
     {
       "title": "## ⬆️ Dependencies",
-      "labels": ["dependencies"]
+      "labels": ["dependencies", "deps"]
+    },
+    {
+      "title": "## 🔧 Maintenance",
+      "labels": ["chore", "maintenance"]
+    },
+    {
+      "title": "## 🧪 Tests",
+      "labels": ["test", "tests"]
     }
   ],
-  "template": "${{CHANGELOG}}\n\n## 📦 Commits\n\n${{COMMITS}}",
-  "pr_template": "- ${{TITLE}} (#${{NUMBER}})",
-  "empty_template": "- No changes"
+  "template": "${{CHANGELOG}}\n\n## 📦 All Changes\n\n${{COMMITS}}",
+  "pr_template": "- ${{TITLE}} (#${{NUMBER}}) by @${{AUTHOR}}",
+  "trim_values": true,
+  "capitalize_title": true,
+  "exclude_merge_branches": ["main", "master"],
+  "custom_placeholders": [
+    {
+      "pattern": "^feat: ",
+      "target": "🚀 "
+    },
+    {
+      "pattern": "^fix: ",
+      "target": "🐛 "
+    },
+    {
+      "pattern": "^docs: ",
+      "target": "📝 "
+    },
+    {
+      "pattern": "^deps: ",
+      "target": "⬆️ "
+    },
+    {
+      "pattern": "^test: ",
+      "target": "🧪 "
+    },
+    {
+      "pattern": "^chore: ",
+      "target": "🔧 "
+    },
+    {
+      "pattern": "^BREAKING CHANGE: ",
+      "target": "💥 "
+    }
+  ],
+  "commit_template": "- ${{TITLE}} (${{HASH}}) by @${{AUTHOR}}",
+  "empty_template": "- No changes",
+  "label_extractor": [
+    {
+      "pattern": "^feat: .+",
+      "target": "feature"
+    },
+    {
+      "pattern": "^fix: .+",
+      "target": "fix"
+    },
+    {
+      "pattern": "^docs: .+",
+      "target": "documentation"
+    },
+    {
+      "pattern": "^chore: .+",
+      "target": "chore"
+    },
+    {
+      "pattern": "^test: .+",
+      "target": "test"
+    },
+    {
+      "pattern": "^deps: .+",
+      "target": "dependencies"
+    }
+  ],
+  "base_branches": ["main", "master"],
+  "sort": "ASC",
+  "transformers": [
+    {
+      "pattern": "^feat: ",
+      "target": "🚀 "
+    },
+    {
+      "pattern": "^fix: ",
+      "target": "🐛 "
+    },
+    {
+      "pattern": "^docs: ",
+      "target": "📝 "
+    },
+    {
+      "pattern": "^chore: ",
+      "target": "🔧 "
+    },
+    {
+      "pattern": "^test: ",
+      "target": "🧪 "
+    },
+    {
+      "pattern": "^deps: ",
+      "target": "⬆️ "
+    }
+  ]
 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,13 +4,19 @@
 
 ## Type of Change
 
-<!-- Please delete options that are not relevant -->
+<!-- Please select ONE option and delete all others.
+This will be used as the PR title prefix and for changelog categorization -->
 
-- [ ] 🚀 New feature (non-breaking change which adds functionality)
-- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-- [ ] 📝 Documentation update
-- [ ] ⬆️ Dependency update
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] feat: New feature (non-breaking change which adds functionality)
+- [ ] fix: Bug fix (non-breaking change which fixes an issue)
+- [ ] docs: Documentation update
+- [ ] deps: Dependency update
+- [ ] test: Adding missing tests or correcting existing tests
+- [ ] chore: Maintenance tasks, refactoring, etc
+- [ ] BREAKING CHANGE: Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+<!-- The PR title should follow the format: "type: description"
+Example: "feat: add support for ReplacingMergeTree engine" -->
 
 ## Testing
 
@@ -25,6 +31,7 @@
 - [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
+- [ ] PR title follows semantic commit format (type: description)
 
 ## Additional Notes
 


### PR DESCRIPTION
## Description

The purpose of this PR is to improve the github actions `release_workflow` to produce richer changelogs, based on the PR title (also changed to follow "semantic" PR titles).

## Type of Change

- [x] 🚀 New feature (non-breaking change which adds functionality)
