### PR TITLE
fix: Update actions to get current and previous tags to correct repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,11 @@ jobs:
 
       - name: Get previous tag
         id: previoustag
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
-        with:
-          fallback: 1.0.0 # Optional fallback tag to use when no tag can be found
+        uses: "younited/get-previous-tag-action@v1.0.0"
 
       - name: Get current tag
         id: currenttag
-        uses: "WyriHaximus/github-action-get-current-tag@v1"
+        uses: "zingimmick/github-action-get-current-tag@v1"
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
## Description

Update the `get-previous-tag` and `get-current-tag` actions to use correct repos.

## Type of Change

- [x] fix: Bug fix (non-breaking change which fixes an issue)